### PR TITLE
docs(typography): document font weights

### DIFF
--- a/source/components/grid/_explorer.less
+++ b/source/components/grid/_explorer.less
@@ -1,4 +1,4 @@
-.demo {
+.grid-demo {
   & > .demo-container {
     border: 1px dotted @gray-400;
   }

--- a/source/components/grid/index.html
+++ b/source/components/grid/index.html
@@ -11,7 +11,7 @@ assets:
 <section>
   <h3 id="responsive">Responsive</h3>
 
-  <div class="demo">
+  <div class="demo grid-demo">
     <div class="demo-container">
       <div id="querySize"></div>
       <div class="hxRow">

--- a/source/components/typography/_explorer.less
+++ b/source/components/typography/_explorer.less
@@ -1,0 +1,13 @@
+.font-roboto {
+  font-family: "Roboto", sans-serif;
+}
+
+.font-roboto-mono {
+  font-family: "Roboto Mono", monospace;
+}
+
+.weight-thin { font-weight: 100; }
+.weight-light { font-weight: 300; }
+.weight-regular { font-weight: 400; }
+.weight-medium { font-weight: 500; }
+.weight-bold { font-weight: 700; }

--- a/source/components/typography/index.html
+++ b/source/components/typography/index.html
@@ -3,6 +3,29 @@ title: Typography
 assets:
   - bootstrap.helix.css
 ---
+<section><!-- Font -->
+  <h2 id="font-weight">Font Weight</h2>
+
+  <div class="demo">
+    <div class="hxRow">
+      <div class="hxCol font-roboto">
+        <p class="weight-thin">Roboto Thin (100)</p>
+        <p class="weight-light">Roboto Light (300)</p>
+        <p class="weight-regular">Roboto Regular (400)</p>
+        <p class="weight-medium">Roboto Medium (500)</p>
+        <p class="weight-bold">Roboto Bold (700)</p>
+      </div>
+      <div class="hxCol font-roboto-mono">
+        <p class="weight-thin">Roboto Mono Thin (100)</p>
+        <p class="weight-light">Roboto Mono Light (300)</p>
+        <p class="weight-regular">Roboto Mono Regular (400)</p>
+        <p class="weight-medium">Roboto Mono Medium (500)</p>
+        <p class="weight-bold">Roboto Mono Bold (700)</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section><!-- Address -->
   <header>
     <h2 id="addresses">Addresses</h2>

--- a/source/styles/explorer.less
+++ b/source/styles/explorer.less
@@ -14,6 +14,7 @@
 */
 @import 'vars.less';
 @import 'grid/_explorer';
+@import 'typography/_explorer';
 @import 'layout';
 
 body {


### PR DESCRIPTION
Adding font-weight documentation to component explorer.

### LGTM's
- [x] Dev LGTM

### Before
![helix-ui-typography-before](https://user-images.githubusercontent.com/545605/29382763-52af26b0-8293-11e7-9da5-2f6119113b42.png)


### After
![helix-ui-typography-after](https://user-images.githubusercontent.com/545605/29382767-57bd97f4-8293-11e7-98c9-24b64ced019e.png)
