### PR TITLE
fix(layout): move CSS to compiled assets

### DIFF
--- a/source/docs.less
+++ b/source/docs.less
@@ -13,7 +13,6 @@
   For distributed HelixUI CSS styles, see source/styles/helix-ui.less
 */
 @import 'vars';
-@import 'layout';
 
 @code-bg-color: @gray-900;
 

--- a/source/helix-ui.less
+++ b/source/helix-ui.less
@@ -12,6 +12,7 @@
 @import  'reset';
 
 // Core CSS
+@import 'layout';
 @import 'scaffold';
 @import 'alert/alert';
 @import 'breadcrumb/breadcrumb';


### PR DESCRIPTION
Layout CSS was incorrectly put into `docs.css` instead of distributed `helix-ui.css`. This PR corrects that problem.

### LGTM's
- [x] Dev LGTM