### PR TITLE
chore(pipeline): add webpack loaders to use external files

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -20,34 +20,11 @@ browserSync.init({
     files: [ // (See 'watchEvents')
         // Reload browser if any file in public directory changes
         `${CONFIG.publicDir}/**/*`,
-
-        // Rebuild compiled JavaScript if any source JS file changes
+        // Rebuild if anything changes in source directory
         {
-            match: `${CONFIG.sourceDir}/**/*.js`,
-            fn: (evt, file) => {
-                Build.scriptsSync();
-            }
-        },
-
-        // Rebuild compiled CSS if any source LESS file changes
-        {
-            match: `${CONFIG.sourceDir}/**/*.less`,
-            fn: (evt, file) => {
-                Build.stylesSync();
-            }
-        },
-
-        // Rebuild docs if any markup file changes
-        {
-            match: `${CONFIG.sourceDir}/**/*.html`,
-            fn: (evt, file) => {
-                Build.docsSync();
-            }
-        },
-
-        // Rebuild everything if anything else changes
-        {
-            match: `${CONFIG.sourceDir}/**/!(*.js|*.less|*.html)`,
+            match: [
+                `${CONFIG.sourceDir}/**/*`
+            ],
             fn: (evt, file) => {
                 Build.buildSync();
             }

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -22,6 +22,22 @@ const compiler = webpack({
                 use: 'svg-inline-loader',
             },
             {
+                test: /\.html$/,
+                use: 'raw-loader'
+            },
+            {
+                test: /\.less$/,
+                use: [
+                    { loader: 'raw-loader' },
+                    {
+                        loader: 'less-loader',
+                        options: {
+                            paths: CONFIG.less.paths
+                        }
+                    }
+                ]
+            },
+            {
                 test: /\.js$/,
                 exclude: /(node_modules|bower_components)/,
                 use: {
@@ -38,7 +54,7 @@ const compiler = webpack({
 
 function compileSync () {
     compiler.run((err, stats) => {
-        if (err || stats.hasErrors()) {
+        if (err) {
             console.log('ERROR: running running webpack');
             console.log(err.message);
         }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "highlight.js": "^9.12.0",
     "js-yaml": "^3.9.1",
     "less": "2.x",
+    "less-loader": "^4.0.5",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "nunjucks": "^3.0.1",
     "pkgcloud": "^1.4.0",
+    "raw-loader": "^0.5.1",
     "svg-inline-loader": "^0.8.0",
     "webpack": "^3.5.5"
   },

--- a/source/components/checkbox/HxCheckbox.js
+++ b/source/components/checkbox/HxCheckbox.js
@@ -4,123 +4,11 @@ const KEY = require('../../lib/KEY');
  */
 
 window.addEventListener('WebComponentsReady', function () {
+    const tagName = 'hx-checkbox';
     const template = document.createElement('template');
 
     template.innerHTML = `
-      <style>
-        :host {
-            background-color: #ffffff;
-            border-color: currentColor;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
-            color: #bdbdbd;
-            display: inline-block;
-            height: 1rem;
-            vertical-align: middle;
-            width: 1rem;
-        }
-
-        :host([hidden]) { display: none; }
-
-        /* default unchecked */
-
-        :host(:hover) {
-            background-color: #e4f9f9;
-            color: #16b9d4;
-        }
-
-        /* default checked */
-
-        :host([checked]) {
-            color: #0c7c84;
-        }
-
-        :host([checked]:hover) {
-            background-color: #e4f9f9;
-            color: #16b9d4;
-        }
-
-        /* default indeterminate (checked or unchecked) */
-
-        :host([indeterminate]) {
-            color: #0c7c84;
-        }
-
-        :host([indeterminate]:hover) {
-            color: #16b9d4;
-        }
-
-        /* invalid unchecked */
-
-        :host([invalid]) {
-            border-width: 2px;
-            color: #d32f2f;
-        }
-
-        :host([invalid]:hover) {
-            background-color: #FFCDD2;
-            color: #d32f2f;
-        }
-
-        /* invalid checked */
-
-        /* invalid indeterminate (checked or unchecked) */
-
-        /* disabled unchecked */
-
-        :host([disabled]) {
-            background-color: #eeeeee;
-            color: #bdbdbd;
-            cursor: not-allowed;
-        }
-
-        :host([disabled]:hover) {
-            background-color: #eeeeee;
-            color: #bdbdbd;
-        }
-
-        /* disabled checked */
-
-        /* disabled indeterminate (checked or unchecked) */
-        :host([disabled][indeterminate]) {
-            color: #bdbdbd;
-        }
-
-        /* ^^ light dom overridable ^^ */
-        #container {
-            align-content: center;
-            align-items: center;
-            display: flex;
-            font-size: 0.625em; /* ~10px */
-            height: 100%;
-            justify-content: center;
-            width: 100%;
-        }
-
-        #minus,
-        #tick {
-            display: none;
-            height: 1em;
-            line-height: 1;
-            width: 1em;
-        }
-
-        /* FIXME: redefine due to bug in hxIcon */
-        hx-icon svg {
-            fill: currentColor;
-            stroke: none;
-        }
-
-        :host([checked]:not([indeterminate])) #tick {
-            display: block;
-        }
-
-        :host([indeterminate]) #minus {
-            display: block;
-        }
-      </style>
-
+      <style>${require('./HxCheckbox.less')}</style>
       <div id="container">
         <hx-icon type="checkmark" id="tick"></hx-icon>
         <hx-icon type="minus" id="minus"></hx-icon>
@@ -135,7 +23,7 @@ window.addEventListener('WebComponentsReady', function () {
 
     class HxCheckbox extends HTMLElement {
         static get is () {
-            return 'hx-checkbox';
+            return tagName;
         }
 
         static get observedAttributes () {
@@ -150,7 +38,7 @@ window.addEventListener('WebComponentsReady', function () {
             super();
             this.attachShadow({mode: 'open'});
             if (window.ShadyCSS) {
-                ShadyCSS.prepareTemplate(template, 'hx-checkbox');
+                ShadyCSS.prepareTemplate(template, tagName);
                 ShadyCSS.styleElement(this);
             }
             this.shadowRoot.appendChild(template.content.cloneNode(true));

--- a/source/components/checkbox/HxCheckbox.less
+++ b/source/components/checkbox/HxCheckbox.less
@@ -1,0 +1,105 @@
+@import 'vars';
+
+:host {
+  background-color: @gray-0;
+  border-color: currentColor;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
+  color: @gray-500;
+  display: inline-block;
+  height: 1rem;
+  vertical-align: middle;
+  width: 1rem;
+
+  &([hidden]) {
+    display: none;
+  }
+
+  /* default unchecked */
+  &(:hover) {
+    background-color: @cyan-50;
+    color: @cyan-500;
+  }
+
+  /* default checked */
+  &([checked]) {
+    color: @cyan-900;
+  }
+
+  &([checked]:hover) {
+    background-color: @cyan-50;
+    color: @cyan-500;
+  }
+
+  /* default indeterminate (checked or unchecked) */
+  &([indeterminate]) {
+    color: @cyan-900;
+  }
+
+  &([indeterminate]:hover) {
+    color: @cyan-500;
+  }
+
+  /* invalid unchecked */
+  &([invalid]) {
+    border-width: 2px;
+    color: @red-900;
+  }
+
+  &([invalid]:hover) {
+    background-color: @red-500;
+    color: @red-900;
+  }
+
+  /* invalid checked */
+
+  /* invalid indeterminate (checked or unchecked) */
+
+  /* disabled unchecked */
+  &([disabled]) {
+    background-color: @gray-100;
+    color: @gray-500;
+    cursor: not-allowed;
+  }
+
+  &([disabled]:hover) {
+    background-color: @gray-100;
+    color: @gray-500;
+  }
+
+  /* disabled checked */
+
+  /* disabled indeterminate (checked or unchecked) */
+  &([disabled][indeterminate]) {
+    color: @gray-500;
+  }
+}
+
+#container {
+  align-content: center;
+  align-items: center;
+  display: flex;
+  font-size: 0.625em; /* ~10px */
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+
+#minus,
+#tick {
+  display: none;
+  height: 1em;
+  line-height: 1;
+  width: 1em;
+}
+
+:host {
+  &([checked]:not([indeterminate])) #tick {
+    display: block;
+  }
+
+  &([indeterminate]) #minus {
+    display: block;
+  }
+}

--- a/source/components/icon/HxIcon.js
+++ b/source/components/icon/HxIcon.js
@@ -1,99 +1,112 @@
 window.addEventListener('WebComponentsReady', function () {
-  const icons = {
-      'angle-down': require('./_images/angle-down.svg'),
-      'angle-left': require('./_images/angle-left.svg'),
-      'angle-right': require('./_images/angle-right.svg'),
-      'angle-up': require('./_images/angle-up.svg'),
-      'calendar': require('./_images/calendar.svg'),
-      'checkmark': require('./_images/checkmark.svg'),
-      'cog': require('./_images/cog.svg'),
-      'download': require('./_images/download.svg'),
-      'envelope': require('./_images/envelope.svg'),
-      'exclamation-circle': require('./_images/exclamation-circle.svg'),
-      'exclamation-triangle': require('./_images/exclamation-triangle.svg'),
-      'export': require('./_images/export.svg'),
-      'fanatiguy': require('./_images/fanatiguy.svg'),
-      'filter': require('./_images/filter.svg'),
-      'info-circle': require('./_images/info-circle.svg'),
-      'input-file': require('./_images/input-file.svg'),
-      'input-number': require('./_images/input-number.svg'),
-      'input-time': require('./_images/input-time.svg'),
-      'input-url': require('./_images/input-url.svg'),
-      'kbd-arrow-down': require('./_images/kbd-arrow-down.svg'),
-      'kbd-arrow-left': require('./_images/kbd-arrow-left.svg'),
-      'kbd-arrow-right': require('./_images/kbd-arrow-right.svg'),
-      'kbd-arrow-up': require('./_images/kbd-arrow-up.svg'),
-      'kbd-capslock': require('./_images/kbd-capslock.svg'),
-      'kbd-command': require('./_images/kbd-command.svg'),
-      'kbd-delete': require('./_images/kbd-delete.svg'),
-      'kbd-eject': require('./_images/kbd-eject.svg'),
-      'kbd-option': require('./_images/kbd-option.svg'),
-      'kbd-return': require('./_images/kbd-return.svg'),
-      'kbd-shift': require('./_images/kbd-shift.svg'),
-      'kbd-space': require('./_images/kbd-space.svg'),
-      'kbd-tab': require('./_images/kbd-tab.svg'),
-      'lock': require('./_images/lock.svg'),
-      'minus': require('./_images/minus.svg'),
-      'phone': require('./_images/phone.svg'),
-      'plus-or-minus': require('./_images/plus-or-minus.svg'),
-      'search': require('./_images/search.svg'),
-      'sort': require('./_images/sort.svg'),
-      'sort-down': require('./_images/sort-down.svg'),
-      'sort-up': require('./_images/sort-up.svg'),
-      'support': require('./_images/support.svg'),
-      'times': require('./_images/times.svg'),
-      'times-circle': require('./_images/times-circle.svg'),
-  };
+    const tagName = 'hx-icon';
+    const template = document.createElement('template');
+    const icons = {
+        'angle-down': require('./_images/angle-down.svg'),
+        'angle-left': require('./_images/angle-left.svg'),
+        'angle-right': require('./_images/angle-right.svg'),
+        'angle-up': require('./_images/angle-up.svg'),
+        'calendar': require('./_images/calendar.svg'),
+        'checkmark': require('./_images/checkmark.svg'),
+        'cog': require('./_images/cog.svg'),
+        'download': require('./_images/download.svg'),
+        'envelope': require('./_images/envelope.svg'),
+        'exclamation-circle': require('./_images/exclamation-circle.svg'),
+        'exclamation-triangle': require('./_images/exclamation-triangle.svg'),
+        'export': require('./_images/export.svg'),
+        'fanatiguy': require('./_images/fanatiguy.svg'),
+        'filter': require('./_images/filter.svg'),
+        'info-circle': require('./_images/info-circle.svg'),
+        'input-file': require('./_images/input-file.svg'),
+        'input-number': require('./_images/input-number.svg'),
+        'input-time': require('./_images/input-time.svg'),
+        'input-url': require('./_images/input-url.svg'),
+        'kbd-arrow-down': require('./_images/kbd-arrow-down.svg'),
+        'kbd-arrow-left': require('./_images/kbd-arrow-left.svg'),
+        'kbd-arrow-right': require('./_images/kbd-arrow-right.svg'),
+        'kbd-arrow-up': require('./_images/kbd-arrow-up.svg'),
+        'kbd-capslock': require('./_images/kbd-capslock.svg'),
+        'kbd-command': require('./_images/kbd-command.svg'),
+        'kbd-delete': require('./_images/kbd-delete.svg'),
+        'kbd-eject': require('./_images/kbd-eject.svg'),
+        'kbd-option': require('./_images/kbd-option.svg'),
+        'kbd-return': require('./_images/kbd-return.svg'),
+        'kbd-shift': require('./_images/kbd-shift.svg'),
+        'kbd-space': require('./_images/kbd-space.svg'),
+        'kbd-tab': require('./_images/kbd-tab.svg'),
+        'lock': require('./_images/lock.svg'),
+        'minus': require('./_images/minus.svg'),
+        'phone': require('./_images/phone.svg'),
+        'plus-or-minus': require('./_images/plus-or-minus.svg'),
+        'search': require('./_images/search.svg'),
+        'sort': require('./_images/sort.svg'),
+        'sort-down': require('./_images/sort-down.svg'),
+        'sort-up': require('./_images/sort-up.svg'),
+        'support': require('./_images/support.svg'),
+        'times': require('./_images/times.svg'),
+        'times-circle': require('./_images/times-circle.svg'),
+    };
 
-  class HxIcon extends HTMLElement {
-      static get is () {
-          return 'hx-icon';
-      }
+    template.innerHTML = `
+        <style>${require('./HxIcon.less')}</style>
+        <slot></slot>
+    `;
 
-      static get observedAttributes() {
-          return ['type'];
-      }
+    class HxIcon extends HTMLElement {
+        static get is () {
+            return tagName;
+        }
 
-      static get icons () {
-          return icons;
-      }
+        static get observedAttributes() {
+            return ['type'];
+        }
 
-      constructor (type) {
-          super();
+        static get icons () {
+            return icons;
+        }
 
-          if (type) {
-              this.setAttribute('type', type);
-          }
-      }
+        constructor (type) {
+            super();
+            this.attachShadow({mode: 'open'});
+            if (window.ShadyCSS ) {
+                ShadyCSS.prepareTemplate(template, tagName);
+                ShadyCSS.styleElement(this);
+            }
+            this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-      connectedCallback () {
-          this._render();
-      }
+            if (type) {
+                this.setAttribute('type', type);
+            }
+        }
 
-      attributeChangedCallback (attr, oldValue, newValue) {
-          if (attr === 'type') {
-              this._render();
-          }
-      }
+        connectedCallback () {
+            this._render();
+        }
 
-      _render () {
-          const type = this.getAttribute('type');
+        attributeChangedCallback (attr, oldValue, newValue) {
+            if (attr === 'type') {
+                this._render();
+            }
+        }
 
-          // erase previously injected markup
-          this.innerHTML = '';
+        _render () {
+            const type = this.getAttribute('type');
 
-          if (type in HxIcon.icons) {
-              // create surrogate DIV to add raw SVG markup
-              const tmpDiv = document.createElement('div');
-              tmpDiv.innerHTML = HxIcon.icons[type];
-              // grab SVG from surrogate DIV
-              const svg = tmpDiv.firstElementChild;
+            // erase previously injected markup
+            this.innerHTML = '';
 
-              // inject SVG into Light DOM
-              this.appendChild(svg);
-          }
-      }//_render()
-  }//HxIcon
+            if (type in HxIcon.icons) {
+                // create surrogate DIV to add raw SVG markup
+                const tmpDiv = document.createElement('div');
+                tmpDiv.innerHTML = HxIcon.icons[type];
+                // grab SVG from surrogate DIV
+                const svg = tmpDiv.firstElementChild;
 
-  customElements.define(HxIcon.is, HxIcon);
+                // inject SVG into Light DOM
+                this.appendChild(svg);
+            }
+        }//_render()
+    }//HxIcon
+
+    customElements.define(HxIcon.is, HxIcon);
 });

--- a/source/components/icon/HxIcon.less
+++ b/source/components/icon/HxIcon.less
@@ -1,5 +1,4 @@
-// Legacy browser support (IE)
-hx-icon {
+:host {
   background-color: inherit;
   color: inherit;
   display: inline-block;
@@ -14,9 +13,9 @@ hx-icon {
     height: 0;
     width: 0;
   }
+}
 
-  svg {
-    fill: currentColor;
-    stroke: none;
-  }
+::slotted(svg) {
+  fill: currentColor;
+  stroke: none;
 }

--- a/source/components/reveal/HxReveal.html
+++ b/source/components/reveal/HxReveal.html
@@ -1,0 +1,6 @@
+<button id="toggle" aria-expanded="false">
+  <slot name="summary"></slot>
+</button>
+<div id="content">
+  <slot></slot>
+</div>

--- a/source/components/reveal/HxReveal.js
+++ b/source/components/reveal/HxReveal.js
@@ -1,62 +1,26 @@
 window.addEventListener('WebComponentsReady', function () {
+    const tagName = 'hx-reveal';
     const template = document.createElement('template');
 
     template.innerHTML = `
-      <style>
-        :host {
-          display: block;
-        }
-    
-        #content {
-          display: none;
-        }
-
-        :host([open]) > #content {
-          display: block;
-        }
-
-        #toggle {
-          background-color: transparent;
-          border: none;
-          color: inherit;
-          font-size: 1em;
-          margin: 0px;
-          padding: 0px;
-          text-align: left;
-          width: 100%;
-        }
-
-        #toggle:empty {
-          display: none;
-        }
-
-        #toggle:hover {
-          cursor: pointer;
-        }
-      </style>
-
-      <button id="toggle" aria-expanded="false">
-        <slot name="summary"></slot>
-      </button>
-      <div id="content">
-        <slot></slot>
-      </div>
+      <style>${require('./HxReveal.less')}</style>
+      ${require('./HxReveal.html')}
     `;
 
     class HxReveal extends HTMLElement {
         static get is () {
-            return 'hx-reveal';
+            return tagName;
         }
 
         static get observedAttributes () {
             return ['open'];
         }
 
-        constructor() {                   
+        constructor () {
             super();
             this.attachShadow({mode: 'open'});
-            if (window.ShadyCSS) { 
-                ShadyCSS.prepareTemplate(template, 'hx-reveal');
+            if (window.ShadyCSS) {
+                ShadyCSS.prepareTemplate(template, tagName);
                 ShadyCSS.styleElement(this);
             }
             this.shadowRoot.appendChild(template.content.cloneNode(true));
@@ -74,7 +38,7 @@ window.addEventListener('WebComponentsReady', function () {
 
         attributeChangedCallback (attr, oldValue, newValue) {
             if (attr === 'open') {
-                this._btnToggle.setAttribute('aria-expanded', newValue === '');    
+                this._btnToggle.setAttribute('aria-expanded', newValue === '');
             }
         }
 

--- a/source/components/reveal/HxReveal.less
+++ b/source/components/reveal/HxReveal.less
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+
+  &([open]) > #content {
+    display: block;
+  }
+}
+
+#content {
+  display: none;
+}
+
+#toggle {
+  background-color: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1em;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+
+  &:empty {
+    display: none;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/source/helix-ui.less
+++ b/source/helix-ui.less
@@ -20,7 +20,6 @@
 @import 'checkbox/checkbox';
 @import 'code/code';
 @import 'grid/grid';
-@import 'icon/icon';
 @import 'list/list';
 @import 'navigation/navigation';
 @import 'reveal/reveal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,15 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^5.1.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    json-schema-traverse "^0.3.0"
+    json-stable-stringify "^1.0.1"
+
 ajv@^5.1.5:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
@@ -282,7 +291,11 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
-aws4@^1.2.1:
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
+aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -792,6 +805,18 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
+boom@4.x.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
+  dependencies:
+    hoek "4.x.x"
+
+boom@5.x.x:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  dependencies:
+    hoek "4.x.x"
+
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
@@ -1073,6 +1098,10 @@ clone@^1.0.0, clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
+clone@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1238,6 +1267,12 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+cryptiles@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
+  dependencies:
+    boom "5.x.x"
 
 crypto-browserify@1.0.9:
   version "1.0.9"
@@ -1761,7 +1796,7 @@ extend@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-1.3.0.tgz#d1516fb0ff5624d2ebf9123ea1dac5a1994004f8"
 
-extend@^3.0.0, extend@~3.0.0:
+extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -1907,6 +1942,14 @@ form-data@~0.1.0:
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
+form-data@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -2234,12 +2277,23 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  dependencies:
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -2315,6 +2369,15 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+hawk@~6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  dependencies:
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
+
 highlight.js@^9.12.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
@@ -2334,6 +2397,10 @@ hoek@0.9.x:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hoek@4.x.x:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2400,6 +2467,14 @@ http-signature@~1.1.0:
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
   dependencies:
     assert-plus "^0.2.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -2761,6 +2836,14 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+less-loader@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-4.0.5.tgz#ae155a7406cac6acd293d785587fcff0f478c4dd"
+  dependencies:
+    clone "^2.1.1"
+    loader-utils "^1.1.0"
+    pify "^2.3.0"
+
 less@2.x:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/less/-/less-2.7.2.tgz#368d6cc73e1fb03981183280918743c5dcf9b3df"
@@ -3078,6 +3161,10 @@ mime-db@~1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.7:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
@@ -3087,6 +3174,12 @@ mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.7:
 mime-types@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-1.0.2.tgz#995ae1392ab8affcbfcb2641dd054e943c0d5dce"
+
+mime-types@~2.1.17:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
 
 mime@1.2.4:
   version "1.2.4"
@@ -3312,7 +3405,7 @@ oauth-sign@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.3.0.tgz#cb540f93bb2b22a7d5941691a288d60e8ea9386e"
 
-oauth-sign@~0.8.1:
+oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -3591,6 +3684,10 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -3735,6 +3832,10 @@ qs@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-1.0.2.tgz#50a93e2b5af6691c31bcea5dae78ee6ea1903768"
 
+qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -3759,6 +3860,10 @@ randombytes@^2.0.0, randombytes@^2.0.1:
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
+raw-loader@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
 
 rc@^1.1.7:
   version "1.2.1"
@@ -3943,7 +4048,7 @@ request@2.40.x:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
-request@2.81.0, request@^2.39.0, request@^2.54.0, request@^2.72.0, request@^2.81.0:
+request@2.81.0, request@^2.39.0, request@^2.54.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -3969,6 +4074,33 @@ request@2.81.0, request@^2.39.0, request@^2.54.0, request@^2.72.0, request@^2.81
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+request@^2.72.0:
+  version "2.83.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4166,6 +4298,12 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+sntp@2.x.x:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
+  dependencies:
+    hoek "4.x.x"
+
 socket.io-adapter@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz#cb6d4bb8bec81e1078b99677f9ced0046066bb8b"
@@ -4331,7 +4469,7 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4:
+stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -4480,6 +4618,12 @@ tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+tough-cookie@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  dependencies:
+    punycode "^1.4.1"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -4603,7 +4747,7 @@ uuid@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 


### PR DESCRIPTION
Adding webpack loader capability to require external files from web component JS.

* Fixes [SURF-653](https://jira.rax.io/browse/SURF-653)
* Support added for loading `*.less` files into javascript as compiled CSS string.
* Support added for loading `*.html` files into javascript as raw string.
* Converted checkbox styling to LESS

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
