### PR TITLE
update(reveal): replace functions with properties

### DIFF
--- a/source/components/reveal/HxReveal.js
+++ b/source/components/reveal/HxReveal.js
@@ -25,15 +25,15 @@ window.addEventListener('WebComponentsReady', function () {
             }
             this.shadowRoot.appendChild(template.content.cloneNode(true));
             this._btnToggle = this.shadowRoot.querySelector('#toggle');
-            this.toggle = this.toggle.bind(this);
+            this._toggle = this._toggle.bind(this);
         }
 
         connectedCallback () {
-            this._btnToggle.addEventListener('click', this.toggle);
+            this._btnToggle.addEventListener('click', this._toggle);
         }
 
         disconnectedCallback () {
-            this._btnToggle.removeEventListener('click', this.toggle);
+            this._btnToggle.removeEventListener('click', this._toggle);
         }
 
         attributeChangedCallback (attr, oldValue, newValue) {
@@ -42,20 +42,20 @@ window.addEventListener('WebComponentsReady', function () {
             }
         }
 
-        toggle () {
-            if (this.getAttribute('open') === '') {
-                this.close();
+        set open (value) {
+            if (Boolean(value)) {
+                this.setAttribute('open', '');
             } else {
-                this.open();
+                this.removeAttribute('open');
             }
         }
 
-        open () {
-            this.setAttribute('open', '');
+        get open () {
+            return this.hasAttribute('open');
         }
 
-        close () {
-            this.removeAttribute('open');
+        _toggle () {
+            this.open = !this.open;
         }
     }
     customElements.define(HxReveal.is, HxReveal)

--- a/source/components/reveal/index.html
+++ b/source/components/reveal/index.html
@@ -52,17 +52,10 @@ assets:
 </section>
 
 <section>
-  <h2 class="hxSectionTitle" id="functions">Functions</h2>
-  <p>The following functions are available on the element.</p>
+  <h2 class="hxSectionTitle" id="properties">Properties</h2>
   <dl>
-    <dt>close()</dt>
-    <dd>Closes the reveal</dd>
-
-    <dt>open()</dt>
-    <dd>Opens the reveal</dd>
-
-    <dt>toggle()</dt>
-    <dd>Inverts the open state</dd>
+    <dt>open <small>(Boolean)</small></dt>
+    <dd>Determines if reveal is open.</dd>
   </dl>
 </section>
 {% endblock %}


### PR DESCRIPTION
Convert methods to properties.

before | after
------ | -----
`el.open()` | `el.open = true`
`el.close()` | `el.open = false`
`el.toggle()` | `el.open = !el.open`

### LGTM's
- [x] Dev LGTM