### PR TITLE
fix(checkbox): correct hover color

### DIFF
--- a/source/components/checkbox/HxCheckbox.less
+++ b/source/components/checkbox/HxCheckbox.less
@@ -48,7 +48,7 @@
   }
 
   &([invalid]:hover) {
-    background-color: @red-500;
+    background-color: @red-100;
     color: @red-900;
   }
 


### PR DESCRIPTION
Due to updated color variables, invalid checkbox had old color red variable for hover state, updated to `red-100`

### LGTM's
- [x] Dev LGTM
