### PR TITLE
chore(package.json): Unix-like platforms only

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,6 @@
   "bugs": {
     "url": "https://github.com/HelixDesignSystem/helix-ui/issues"
   },
-  "homepage": "https://github.com/HelixDesignSystem/helix-ui#readme"
+  "homepage": "https://github.com/HelixDesignSystem/helix-ui#readme",
+  "os": [ "!win32" ]
 }


### PR DESCRIPTION
Set `package.os` to support development in Unix-like operating systems, only.

JIRA: n/a

### LGTM's
- [x] Dev LGTM