### PR TITLE
Changes to Breadcrumb as per design spec

### DIFF
--- a/src/less/components/breadcrumb/index.less
+++ b/src/less/components/breadcrumb/index.less
@@ -5,12 +5,11 @@
   display: flex;
   font-size: 0.75rem;
   font-weight: 500;
-  height: 1.75rem;
-  margin-bottom: 1rem;
-  text-transform: uppercase;
+  line-height: 1;
 
   & > a {
     margin-right: 0.5rem;
+    text-transform: capitalize;
 
     &:last-of-type {
       color: @gray-600;


### PR DESCRIPTION
JIRA: SURF-1772

1. Applied spacing as per the design spec.

2. As per the design spec, title case needs to be applied for the text string in root or child nodes in the breadcrumb. text-transform: capitalize does not get applied on capital string and/or on capital letters within the words in breadcrumb string. For now, Applied fix to change only the first letter of the text string to capital.

3. Changed CSS properties order just to reflect box model first.

4. Ignored about ellipses for lengthier string as the anchor element is anyhow inline element and the text flows in to next line.

Please include Design LGTM, if approval required on the second point above.


### LGTM's
- [x] Dev LGTM
- [x] Design LGTM