### PR TITLE
refactor(src): deprecate .hxComponent in LESS

### DIFF
--- a/src/less/components.less
+++ b/src/less/components.less
@@ -1,5 +1,6 @@
 @import "vars";
 
+// DEPRECATED! Use SCSS, instead!
 .hxComponent {
   color: @gray-900;
   font-family: "Roboto", sans-serif;
@@ -48,4 +49,3 @@
 @import 'components/text-input/index';
 @import 'components/textarea/index';
 @import 'components/toast/index';
-@import 'components/tooltip/index';

--- a/src/scss/components/_config.scss
+++ b/src/scss/components/_config.scss
@@ -1,0 +1,21 @@
+@import "vars";
+
+// intended to be @extend'ed, in order to combine
+// styles into a single selector block for multiple elements
+%hxComponent {
+  color: $gray-900;
+  font-family: "Roboto", sans-serif;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  letter-spacing: normal;
+  line-height: 1.5;
+  text-align: left;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+}

--- a/src/scss/components/_index.scss
+++ b/src/scss/components/_index.scss
@@ -1,9 +1,10 @@
 @import "accordion/index";
 @import "alert/index";
 @import "badge/index";
+@import "box/index";
 @import "breadcrumb/index";
 @import "icon/index";
-@import "box/index";
 @import "loader/index";
 @import "selector-strip/index";
+@import "tooltip/index";
 @import "typography/index";

--- a/src/scss/components/tooltip/_index.scss
+++ b/src/scss/components/tooltip/_index.scss
@@ -1,11 +1,14 @@
-@import (reference) 'mixins';
+@import "vars";
+@import "mixins";
+@import "../config";
 
-hx-tooltip:extend(.hxComponent) {
-  #Positionable.base();
+hx-tooltip {
+  @extend %hxComponent;
+  @include is-positionable;
 
   font-size: 0.875rem;
   max-width: 25rem; // 400px
-  z-index: @tooltip-z-index;
+  z-index: $tooltip-z-index;
 
   &[open] {
     display: inline-block;


### PR DESCRIPTION
* add `src/scss/components/_hxComponent.scss` with %hxComponent placeholder styles
* convert Tooltip to SCSS in order to verify %hxComponent implementation

JIRA: SURF-1893 (also SURF-1902)

### LGTM's
- [x] Dev LGTM

### CSS Comparison

*extending `%hxComponent`* (new CSS on left)
![CleanShot 2019-09-26 at 15 52 27@2x](https://user-images.githubusercontent.com/545605/65724948-29e34100-e077-11e9-9d7d-509d9fd04991.png)

*remaining `hx-tooltip` styles* (new CSS on left)
![CleanShot 2019-09-26 at 15 52 49@2x](https://user-images.githubusercontent.com/545605/65724994-40899800-e077-11e9-8239-62e0917a5f1b.png)
