### PR TITLE
chore: remove docs homepage date updated

### DIFF
--- a/docs/_templates/application.njk
+++ b/docs/_templates/application.njk
@@ -148,14 +148,16 @@
     </div>
 
     <div class="hxCol hxRight">
-      {% if page.updated %}
+{# The date provided does not correlate to release date.  TODO: remove? #}
+{#  {% if page.updated %}
         <small>
           Last Updated:
           {{ page.updated.format(site.dateFormat) }}
         </small>
       {% endif %}
-
+#}
       <small>
+        Latest Release:
         (<a href="https://github.com/HelixDesignSystem/helix-ui/releases/v{{VERSION}}" target="_blank">
           v{{VERSION}}
         </a>)


### PR DESCRIPTION
# Fix docs homepage footer

The date provided does not correlate to release date.


## Before

<img width="237" alt="Screen Shot 2020-04-01 at 3 34 52 PM" src="https://user-images.githubusercontent.com/10120600/78183959-59ac4080-742e-11ea-8768-dee817b9d935.png">

## After

<img width="168" alt="Screen Shot 2020-04-01 at 3 36 04 PM" src="https://user-images.githubusercontent.com/10120600/78184091-8d876600-742e-11ea-9288-ea3da6524a59.png">


#### JIRA: SURF-1990

### LGTM's
* [x] Dev LGTM
