### PR TITLE
test(hx-busy): restructure and add additional tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,11 +8,12 @@ Jira:
 
 ## Before you request a review for this PR:
 
-- [ ] Did you manually test in recent versions of modern browsers (Chrome, Firefox, Safari, and Chromium-based Edge)?
-- [ ] Did you manually test in IE and legacy Edge?
-- [ ] Did you add unit tests for any new code if needed?
-- [ ] Did you run the unit tests via `yarn test` to ensure they all pass?
-- [ ] Did you update the demo page and documentation if you changed/added functionality?
+- [ ] For UI changes, did you manually test in recent versions of modern browsers (Chrome, Firefox, and Safari)?
+- [ ] For UI changes, did you manually test in IE11 and legacy Edge?
+- [ ] Did you add component tests for any new code?
+- [ ] Did you run the component unit tests via `yarn test` to ensure all tests passed?
+- [ ] Did you include a screenshot of the component tests?
+- [ ] If you changed/added functionality, did you update the demo page and documentation?
 - [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
 - [ ] Did you assign reviewers?
-- [ ] Have you linked to this PR from the Jira ticket(s)?
+- [ ] In Jira, have you linked to this PR on the ticket(s)?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
-sudo: required
-dist: trusty
+sudo: false
+dist: xenial
+os:
+  - linux
 language: node_js
 node_js:
   - '12'
 notifications:
   email: false
 addons:
-  firefox: '61.0'
+  firefox: latest
+  chrome: stable
   #sauce_connect: true
 branch:
   only:

--- a/karma-init.js
+++ b/karma-init.js
@@ -1,3 +1,9 @@
-import HelixUI from './dist/js/helix-ui.module.js';
-HelixUI.initialize();
+/**
+ * @overview Karma start script.
+ *
+ * Used to initialize HelixUI ES Modules for testing.
+ */
 
+import HelixUI from './dist/js/helix-ui.module.js';
+
+HelixUI.initialize();

--- a/src/elements/hx-busy/index.js
+++ b/src/elements/hx-busy/index.js
@@ -12,10 +12,6 @@ export class HXBusyElement extends HXElement {
         return 'hx-busy';
     }
 
-    static get template () {
-        return '';
-    }
-
     $onConnect () {
         this.$upgradeProperty('paused');
         this.$defaultAttribute('aria-hidden', true);

--- a/src/elements/hx-busy/index.spec.js
+++ b/src/elements/hx-busy/index.spec.js
@@ -6,31 +6,82 @@ import { fixture, expect } from '@open-wc/testing';
  * @type HXBusyElement
  *
  */
-describe('<hx-busy> tests', () => {
+describe('<hx-busy> component tests', () => {
     const template = '<hx-busy>';
 
-    it('should be instantiated with hx-defined attribute', async () => {
-        const el = /** @type {HXBusyElement} */ await fixture(template);
+    describe('instantiate element', () => {
+        it('should be instantiated with hx-defined attribute', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            const attr = component.hasAttribute('hx-defined');
 
-        expect(el.getAttribute('hx-defined')).to.exist;
+            expect(attr).to.be.true;
+        });
+
+        it('should not be hidden', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            const prop = component.hidden;
+
+            expect(prop).to.be.false;
+        });
+
+        it(`the rendered light DOM should NOT equal simple template ${template}`, async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+
+            expect(component).lightDom.to.not.equal(template);
+        });
+
+        it(`should NOT have a Shadow DOM`, async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            const shadow = component.shadowRoot;
+
+            expect(shadow).to.be.null;
+        });
     });
 
-    it('should have aria-hidden attribute set to true', async () => {
-        const el = /** @type {HXBusyElement} */ await fixture(template);
+    describe('test $onConnect method', () => {
+        it('should not be paused on connect', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            const prop = component.hasAttribute('paused');
 
-        expect(el.getAttribute('aria-hidden')).to.be.equal(String(true));
+            expect(prop).to.be.false;
+        });
+
+        it('should have aria-hidden attribute', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            const attr = component.hasAttribute('aria-hidden');
+
+            expect(attr).to.be.true;
+        });
+
+        it('should have aria-hidden attribute set to true', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            const attr = component.getAttribute('aria-hidden');
+
+            expect(attr).to.be.equal(String(true));
+        });
     });
 
-    it(`the rendered light DOM should NOT equal simple template ${template}`, async () => {
-        const el = /** @type {HXBusyElement} */ await fixture(template);
+    describe('test <hx-busy> getter and setter methods', () => {
+        it('should be able to pause element', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            component.paused = true;
+            const attr = component.hasAttribute('paused');
 
-        expect(el).lightDom.to.not.equal(template);
+            expect(attr).to.be.true;
+        });
+
+        it('should be able to pause and unpause element', async () => {
+            const component = /** @type {HXBusyElement} */ await fixture(template);
+            component.paused = true;
+            let attr = component.hasAttribute('paused');
+
+            expect(attr).to.be.true;
+
+            component.paused = false;
+            attr = component.hasAttribute('paused');
+
+            expect(attr).to.be.false;
+        });
     });
 
-    it(`should NOT have a Shadow DOM`, async () => {
-        const el = /** @type {HXBusyElement} */ await fixture(template);
-        const sd = el.shadowRoot;
-
-        expect(sd).to.be.null;
-    });
 });


### PR DESCRIPTION
## Description

Adding additional tests to `<hx-busy>`:

* add more describe blocks
* add component specific tests

Also:
* update pull request template
* update `TravisCI` config.

## Screenshot of `<hx-busy>` tests

<img width="523" alt="Screen Shot 2020-05-11 at 3 06 07 PM" src="https://user-images.githubusercontent.com/10120600/81606579-f69cba80-9398-11ea-92b6-7c7edd8394bb.png">

### What are the relevant story cards/tickets? Any additional PRs or other references?

Jira: SURF-2051

## Before you request a review for this PR:

- [ ] For UI changes, did you manually test in recent versions of modern browsers (Chrome, Firefox, and Safari)?
- [ ] For UI changes, did you manually test in IE11 and legacy Edge?
- [x] Did you add component tests for any new code?
- [x] Did you run the component unit tests via `yarn test` to ensure all tests passed?
- [x] Did you include a screenshot of the component tests?
- [ ] If you changed/added functionality, did you update the demo page and documentation?
- [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
- [x] Did you assign reviewers?
- [x] In Jira, have you linked to this PR on the ticket(s)?
