### PR TITLE
test(hx-alert): add check for IE11, legacy Edge

### DIFF
--- a/karma.sauce.config.js
+++ b/karma.sauce.config.js
@@ -68,7 +68,7 @@ module.exports = config => {
 				testName: 'HelixUI Component Unit Tests',
                 public: "public restricted",
                 recordVideo: false,
-                // recordLogs: false,
+                recordLogs: false,
 			},
 			customLaunchers: customLaunchers,
 			browsers: Object.keys(customLaunchers),

--- a/src/elements/hx-alert/index.spec.js
+++ b/src/elements/hx-alert/index.spec.js
@@ -63,88 +63,98 @@ describe('<hx-alert> component tests', () => {
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const name = component.slot;
 
-                expect(name).to.be.equal('');
+                if ( name !== null ) {
+                    expect(name).to.be.equal('');
+                } else {
+                    expect(name).to.be.null;  // IE11, Legacy Edge, and older browsers
+                }
             });
         });
 
         describe('verify Shadow DOM markup', () => {
             it('markup should contain a #hxIconWrapper <span>', async () => {
-                const spanId = 'hxIconWrapper';
+                const elSelector = 'span#hxIconWrapper';
+                const id = 'hxIconWrapper';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.getElementById(spanId);
+                const query = shadow.querySelector(elSelector);
                 const queryId = query.id;
 
-                expect(queryId).to.equal(spanId);
+                expect(queryId).to.equal(id);
             });
 
             it('markup should contain a #hxIconWrapper <span> with an info-circle type <hx-icon>', async () => {
-                const spanId = '#hxIconWrapper > hx-icon';
+                const elSelector = 'span#hxIconWrapper > hx-icon';
                 const iconType = 'info-circle';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.querySelector(spanId);
+                const query = shadow.querySelector(elSelector);
                 const queryId = query.type;
 
                 expect(queryId).to.equal(iconType);
             });
 
             it('markup should contain a #hxContent <span>', async () => {
-                const spanId = 'hxContent';
+                const elSelector = 'span#hxContent';
+                const id = 'hxContent';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.getElementById(spanId);
+                const query = shadow.querySelector(elSelector);
                 const queryId = query.id;
 
-                expect(queryId).to.equal(spanId);
+                expect(queryId).to.equal(id);
             });
 
             it('markup should contain a #hxContent <span> with #hxStatus <span>', async () => {
-                const spanId = '#hxContent > #hxStatus';
+                const elSelector = 'span#hxContent > span#hxStatus';
+                const id = 'hxStatus';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.querySelector(spanId);
-                const name = query.localName;
+                const query = shadow.querySelector(elSelector);
+                const queryId = query.id;
 
-                expect(name).to.equal('span');
+                expect(queryId).to.equal(id);
             });
 
-            it('markup should contain a #hxContent <span> with <slot>', async () => {
-                const templateSelector = '#hxContent > slot';
+            it('markup should contain a #hxContent <span>', async () => {
+                const elSelector = 'span#hxContent';
+                const id = 'hxContent';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.querySelector(templateSelector);
-                const name = query.localName;
+                const query = shadow.querySelector(elSelector);
+                const queryId = query.id;
 
-                expect(name).to.equal('slot');
+                expect(queryId).to.equal(id);
             });
 
             it('markup should contain a #hxCta button', async () => {
-                const btnId = 'hxCta';
+                const elSelector = 'button#hxCta';
+                const id = 'hxCta';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.getElementById(btnId);
+                const query = shadow.querySelector(elSelector);
                 const queryId = query.id;
 
-                expect(queryId).to.equal(btnId);
+                expect(queryId).to.equal(id);
             });
 
             it('markup should contain a #hxDismiss button', async () => {
-                const btnId = 'hxDismiss';
+                const elSelector = 'button#hxDismiss';
+                const id = 'hxDismiss';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.getElementById(btnId);
+                const query = shadow.querySelector(elSelector);
                 const queryId = query.id;
 
-                expect(queryId).to.equal(btnId);
+                expect(queryId).to.equal(id);
             });
 
             it('markup should contain a #hxDismiss button with a times type <hx-icon>', async () => {
-                const templateSelector = '#hxDismiss > hx-icon';
+                const elSelector = 'button#hxDismiss > hx-icon';
                 const iconType = 'times';
                 const component = /** @type { HXAlertElement } */ await fixture(template);
                 const shadow = component.shadowRoot;
-                const query = shadow.querySelector(templateSelector);
+                const query = shadow.querySelector(elSelector);
                 const queryId = query.type;
 
                 expect(queryId).to.equal(iconType);
@@ -201,13 +211,13 @@ describe('<hx-alert> component tests', () => {
     describe('test adding content and click event listener', () => {
         it('should be able to add miscellaneous Light DOM content', async () => {
             const component = /** @type {HXAlertElement} */ await fixture(template);
-            const content = 'misc content to Light DOM';
+            const content = 'add misc content to Light DOM';
 
-            expect(component.innerText).to.equal('');
+            expect(component.textContent).to.equal('');
 
             component.textContent = content;
 
-            expect(component.innerText).to.equal(component.textContent);
+            expect(component.textContent).to.equal(content);
         });
 
         it('should fire a click event', async () => {


### PR DESCRIPTION
## Description

Patching `<hx-alert>` for IE11, legacy Edge, and older browsers.

### Screenshot of `<hx-alert>` component tests

<img width="701" alt="Screen Shot 2020-05-18 at 4 01 55 PM" src="https://user-images.githubusercontent.com/10120600/82259303-f4020e00-9920-11ea-8787-ef62026ce374.png">

### What are the relevant story cards/tickets? Any additional PRs or other references?

Jira: SURF-2052

## Before you request a review for this PR:

- [x] For UI changes, did you manually test in recent versions of modern browsers (Chrome, Firefox, and Safari)?
- [x] For UI changes, did you manually test in IE11 and legacy Edge?
- [x] Did you add component tests for any new code?
- [x] Did you run the component unit tests via `yarn test` to ensure all tests passed?
- [x] Did you include a screenshot of the component tests?
- [ ] If you changed/added functionality, did you update the demo page and documentation?
- [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
- [ ] Did you assign reviewers?
- [x] In Jira, have you linked to this PR on the ticket(s)?
