### PR TITLE
publish(npm): v0.22.0 [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helix-ui",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Web Component Library",
   "keywords": [
     "custom elements",


### PR DESCRIPTION
Version bump.  New `HelixUI` release.  