### PR TITLE
feat(hx-search-control): add event listener and component tests

### DIFF
--- a/src/elements/hx-search-control/index.js
+++ b/src/elements/hx-search-control/index.js
@@ -23,11 +23,13 @@ export class HXSearchControlElement extends HXFormControlElement {
 
         this._btnReset.addEventListener('click', this._onResetClick);
         this.controlElement.addEventListener('input', this._onControlInput);
+        this.controlElement.addEventListener('change', this._onControlInput);
     }
 
     $onDisconnect () {
         this._btnReset.removeEventListener('click', this._onResetClick);
         this.controlElement.removeEventListener('input', this._onControlInput);
+        this.controlElement.removeEventListener('change', this._onControlInput);
     }
 
     /**

--- a/src/elements/hx-search-control/index.spec.js
+++ b/src/elements/hx-search-control/index.spec.js
@@ -1,0 +1,109 @@
+import { fixture, expect, oneEvent } from '@open-wc/testing';
+
+/**
+ * <hx-search-control> component tests
+ *
+ * @type HXSearchControlElement
+ *
+ */
+describe('<hx-search-control> component tests', () => {
+    const template = '<hx-search-control>';
+    const mockup = `
+            <hx-search-control>
+                <input
+                    id="demoSearch"
+                    type="search"
+                />
+                <button
+                    type="button"
+                    class="hxClear"
+                    aria-label="Clear search"
+                hidden>
+                <hx-icon type="times"></hx-icon>
+                </button>
+                <hx-search></hx-search>
+                <label
+                    for="demoSearch">
+                    Username
+                </label>
+            </hx-search-control>`;
+
+    describe('instantiate element', () => {
+        it('should be instantiated with hx-defined attribute', async () => {
+            const fragment = /** @type {HXSearchControlElement} */ await fixture(mockup);
+            const attr = fragment.hasAttribute('hx-defined');
+
+            expect(attr).to.be.true;
+        });
+
+        it('should not be hidden', async () => {
+            const fragment = /** @type {HXSearchControlElement} */ await fixture(mockup);
+            const prop = fragment.hidden;
+
+            expect(prop).to.be.false;
+        });
+
+        it(`the rendered light DOM should NOT equal simple template ${template}`, async () => {
+            const fragment = /** @type {HXSearchControlElement} */ await fixture(mockup);
+
+            expect(fragment).lightDom.to.not.equal(template);
+        });
+
+        it(`should NOT have a Shadow DOM`, async () => {
+            const fragment = /** @type {HXSearchControlElement} */ await fixture(mockup);
+            const shadow = fragment.shadowRoot;
+
+            expect(shadow).to.be.null;
+        });
+    });
+
+    describe('test for event listeners', () => {
+        it('should fire a input event', async () => {
+            const fragment = /** @type { HXSearchControlElement } */ await fixture(mockup);
+            const detail = { evt: 'input!' };
+            const customEvent = new CustomEvent('input', { detail });
+
+            setTimeout(() => fragment.dispatchEvent(customEvent));
+            const evt = await oneEvent(fragment, 'input');
+
+            expect(evt).to.equal(customEvent);
+            expect(evt.detail).to.equal(detail);
+        });
+
+        it('should fire a click event', async () => {
+            const fragment = /** @type { HXSearchControlElement } */ await fixture(mockup);
+            const detail = { evt: 'click!' };
+            const customEvent = new CustomEvent('click', { detail });
+
+            setTimeout(() => fragment.dispatchEvent(customEvent));
+            const evt = await oneEvent(fragment, 'click');
+
+            expect(evt).to.equal(customEvent);
+            expect(evt.detail).to.equal(detail);
+        });
+
+        it('should fire a change event', async () => {
+            const fragment = /** @type { HXSearchControlElement } */ await fixture(mockup);
+            const detail = { evt: 'change!' };
+            const customEvent = new CustomEvent('change', { detail });
+
+            setTimeout(() => fragment.dispatchEvent(customEvent));
+            const evt = await oneEvent(fragment, 'change');
+
+            expect(evt).to.equal(customEvent);
+            expect(evt.detail).to.equal(detail);
+        });
+
+    });
+
+    describe('test for control element', () => {
+        it('test for control element for input type serach', async ()=> {
+            const fragment = /** @type {HXSearchControlElement} */ await fixture(mockup);
+            const id = 'demoSearch';
+            const ctrl = fragment.controlElement;
+            const ctrlID = ctrl.id;
+
+            expect(ctrlID).to.equal(id);
+        });
+    });
+});


### PR DESCRIPTION
## Description

Test Case `<hx-search-control>`

![image](https://user-images.githubusercontent.com/17586567/87023784-dbfa8c80-c1f5-11ea-9027-389b583e1790.png)

### What are the relevant story cards/tickets? Any additional PRs or other references?

Jira: SURF 2062

## Before you request a review for this PR:

- [x] Did you add component tests for any new code?
- [x] Did you run the component unit tests via `yarn test` to ensure all tests passed?
- [x] Did you include a screenshot of the component tests?
- [ ] If you changed/added functionality, did you update the demo page and documentation?
- [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
- [x] Did you assign reviewers?
- [x] In Jira, have you linked to this PR on the ticket(s)?
