### PR TITLE
docs(faq): fix typo

### DIFF
--- a/docs/guides/faq/index.html
+++ b/docs/guides/faq/index.html
@@ -294,7 +294,7 @@ title: Frequently Asked Questions
         <tr>
           <th scope="row">
             <a href="#esm-for-modern-bundlers">ESM for Modern Bundlers</a><br />
-            <small class="hxSubdued">ECMAScript 5 / ES5</small>
+            <small class="hxSubdued">ECMAScript 2015+ / ES6+</small>
           </th>
           <td><code>helix-ui.esm.js</code></td>
           <td>&mdash;</td>


### PR DESCRIPTION
"ESM for Modern Bundlers" is actually...

* **module:** ESM
* **syntax:** ES2015+ / ES6+
