### PR TITLE
fix(tabset): dynamic tabs bug fixes Issue #516

### DIFF
--- a/src/elements/hx-tab/index.spec.js
+++ b/src/elements/hx-tab/index.spec.js
@@ -71,7 +71,7 @@ describe('<hx-tab> component tests', () => {
 
     describe('test for click event listener', () => {
         it('should fire a click event', async () => {
-            const component = /** @type { HXTabElement } */ await fixture(template);
+            const component = /** @type {HXTabElement} */ await fixture(template);
             const detail = { evt: 'clicked!'};
             const customEvent = new CustomEvent('click', { detail });
 
@@ -88,8 +88,8 @@ describe('<hx-tab> component tests', () => {
      * elements.  These tests will be skipped until we implement a solution
      * for dynamically adding tabs (HelixUI Issue#516).
      */
-    describe.skip('tests should FAIL until fix applied to HelixUI Issue#516', () => {
-        it('should FAIL on render with NO ID on <hx-tabset>', async () => {
+    describe('test fix applied to HelixUI Issue#516', () => {
+        it('should render with NO ID on <hx-tabset>', async () => {
             const mockup = `
                 <hx-tabset current-tab="0">
                     <hx-tablist>
@@ -104,53 +104,59 @@ describe('<hx-tab> component tests', () => {
                     </hx-tabcontent>
                 </hx-tabset>`;
 
-            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector(elSelector).id;
+            const attr = fragment.hasAttribute('id');
+            const id = fragment.getAttribute('id');
 
-            expect(queryId).to.not.be.null;
+            expect(attr).to.be.true;
+            expect(id).to.not.be.null;
         });
 
-        it('should FAIL on render with NO initial <hx-tab>s', async () => {
+        it('should render with NO initial <hx-tab>', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
+                    <hx-tabset>
+                        <hx-tablist>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
+                        <hx-tabcontent>
                           <hx-tabpanel></hx-tabpanel>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabElement} */ await fixture(mockup);
-            const currentTabId = fragment.querySelector('hx-tab').id;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(currentTabId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tabpanel>s', async () => {
+        it('should render with NO tabpanel', async () => {
             const mockup =`
-            <div class="hxPanel hxTabbed">
-                <hx-tabset id="tab-component-tests">
-                    <hx-tablist id="tablist">
-                        <hx-tab id="tab-1" current="true"></hx-tab>
-                    </hx-tablist>
-                    <hx-tabcontent id="tabcontent">
-                    </hx-tabcontent>
-                </hx-tabset>
-            </div>`;
+                <div class="hxPanel hxTabbed">
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                            <hx-tab></hx-tab>
+                        </hx-tablist>
+                        <hx-tabcontent>
+                        </hx-tabcontent>
+                    </hx-tabset>
+                </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector('hx-tabpanel').id;
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const len = tabpanels.length;
 
-            expect(queryId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO tabs or tabpanels', async () => {
+        it('should render with NO tabs or tabpanels', async () => {
             const mockup = `
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tabTest">
+                    <hx-tabset>
                         <hx-tablist>
                         </hx-tablist>
                         <hx-tabcontent>
@@ -158,10 +164,12 @@ describe('<hx-tab> component tests', () => {
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabElement} */ await fixture(mockup);
-            const queryTabs = fragment.tabs.length;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryTabs).to.equal(0);
+            expect(len).to.equal(0);
         });
     });
 });

--- a/src/elements/hx-tabcontent/index.spec.js
+++ b/src/elements/hx-tabcontent/index.spec.js
@@ -78,8 +78,8 @@ describe('<hx-tabcontent> component tests', () => {
      * elements.  These tests will be skipped until we implement a solution
      * for dynamically adding tabs (HelixUI Issue#516).
      */
-    describe.skip('tests should FAIL until fix applied to HelixUI Issue#516', () => {
-        it('should FAIL on render with NO ID on <hx-tabset>', async () => {
+    describe('test fix applied to HelixUI Issue#516', () => {
+        it('should render with NO ID on <hx-tabset>', async () => {
             const mockup = `
                 <hx-tabset current-tab="0">
                     <hx-tablist>
@@ -94,53 +94,59 @@ describe('<hx-tabcontent> component tests', () => {
                     </hx-tabcontent>
                 </hx-tabset>`;
 
-            const elSelector = 'hx-tabset';
-            const fragment = /** @type {HXTabcontentElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector(elSelector).id;
+            const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
+            const attr = fragment.hasAttribute('id');
+            const id = fragment.getAttribute('id');
 
-            expect(queryId).to.not.be.null;
+            expect(attr).to.be.true;
+            expect(id).to.not.be.null;
         });
 
-        it('should FAIL on render with NO initial <hx-tab>s', async () => {
+        it('should render with NO initial <hx-tab>', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
+                    <hx-tabset>
+                        <hx-tablist>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
+                        <hx-tabcontent>
                           <hx-tabpanel></hx-tabpanel>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
-            const fragment = /** @type {HXTabcontentElement} */ await fixture(mockup);
-            const currentTabId = fragment.querySelector('hx-tab').id;
+            const elSelector = 'hx-tabset';
+            const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(currentTabId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tabpanel>s', async () => {
+        it('should render with NO tabpanel', async () => {
             const mockup =`
-            <div class="hxPanel hxTabbed">
-                <hx-tabset id="tab-component-tests">
-                    <hx-tablist id="tablist">
-                        <hx-tab id="tab-1" current="true"></hx-tab>
-                    </hx-tablist>
-                    <hx-tabcontent id="tabcontent">
-                    </hx-tabcontent>
-                </hx-tabset>
-            </div>`;
+                <div class="hxPanel hxTabbed">
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                            <hx-tab></hx-tab>
+                        </hx-tablist>
+                        <hx-tabcontent>
+                        </hx-tabcontent>
+                    </hx-tabset>
+                </div>`;
 
-            const fragment = /** @type {HXTabcontentElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector('hx-tabpanel').id;
+            const elSelector = 'hx-tabset';
+            const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const len = tabpanels.length;
 
-            expect(queryId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO tabs or tabpanels', async () => {
+        it('should render with NO tabs or tabpanels', async () => {
             const mockup = `
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tabTest">
+                    <hx-tabset>
                         <hx-tablist>
                         </hx-tablist>
                         <hx-tabcontent>
@@ -148,10 +154,12 @@ describe('<hx-tabcontent> component tests', () => {
                     </hx-tabset>
                 </div>`;
 
-            const fragment = /** @type {HXTabcontentElement} */ await fixture(mockup);
-            const queryTabs = fragment.tabs.length;
+            const elSelector = 'hx-tabset';
+            const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryTabs).to.equal(0);
+            expect(len).to.equal(0);
         });
     });
 });

--- a/src/elements/hx-tablist/index.spec.js
+++ b/src/elements/hx-tablist/index.spec.js
@@ -48,8 +48,8 @@ describe('<hx-tablist> component tests', () => {
      * elements.  These tests will be skipped until we implement a solution
      * for dynamically adding tabs (HelixUI Issue#516).
      */
-    describe.skip('tests should FAIL until fix applied to HelixUI Issue#516', () => {
-        it('should FAIL on render with NO ID on <hx-tabset>', async () => {
+    describe('test fix applied to HelixUI Issue#516', () => {
+        it('should render with NO ID on <hx-tabset>', async () => {
             const mockup = `
                 <hx-tabset current-tab="0">
                     <hx-tablist>
@@ -61,56 +61,64 @@ describe('<hx-tablist> component tests', () => {
                         <hx-tabpanel id="panel-1" open></hx-tabpanel>
                         <hx-tabpanel id="panel-2"></hx-tabpanel>
                         <hx-tabpanel id="panel-3"></hx-tabpanel>
+                        <hx-tabpanel></hx-tabpanel>
                     </hx-tabcontent>
                 </hx-tabset>`;
 
+            const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
+            const attr = fragment.hasAttribute('id');
+            const id = fragment.getAttribute('id');
+
+            expect(attr).to.be.true;
+            expect(id).to.not.be.null;
+        });
+
+        it('should render with NO initial <hx-tab>', async () => {
+            const mockup =`
+                <div class="hxPanel hxTabbed">
+                    <hx-tabset>
+                        <hx-tablist>
+                        </hx-tablist>
+                        <hx-tabcontent>
+                            <hx-tabpanel></hx-tabpanel>
+                            <hx-tabpanel></hx-tabpanel>
+                        </hx-tabcontent>
+                    </hx-tabset>
+                </div>`;
+
             const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector(elSelector).id;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryId).to.not.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tab>s', async () => {
+        it('should render with NO tabpanel', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                            <hx-tab></hx-tab>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
-                          <hx-tabpanel></hx-tabpanel>
+                        <hx-tabcontent>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
-            const currentTabId = fragment.querySelector('hx-tab').id;
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const len = tabpanels.length;
 
-            expect(currentTabId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tabpanel>s', async () => {
-            const mockup =`
-                <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
-                            <hx-tab id="tab-1" current="true"></hx-tab>
-                        </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
-                        </hx-tabcontent>
-                    </hx-tabset>
-                </div>`;
-
-            const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector('hx-tabpanel').id;
-
-            expect(queryId).to.be.null;
-        });
-
-        it('should FAIL on render with NO tabs or tabpanels', async () => {
+        it('should render with NO tabs or tabpanels', async () => {
             const mockup = `
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tabTest">
+                    <hx-tabset>
                         <hx-tablist>
                         </hx-tablist>
                         <hx-tabcontent>
@@ -118,10 +126,12 @@ describe('<hx-tablist> component tests', () => {
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTablistElement} */ await fixture(mockup);
-            const queryTabs = fragment.tabs.length;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryTabs).to.equal(0);
+            expect(len).to.equal(0);
         });
     });
 });

--- a/src/elements/hx-tabpanel/index.spec.js
+++ b/src/elements/hx-tabpanel/index.spec.js
@@ -110,8 +110,8 @@ describe('<hx-tabpanel> component tests', () => {
      * elements.  These tests will be skipped until we implement a solution
      * for dynamically adding tabs (HelixUI Issue#516).
      */
-    describe.skip('tests should FAIL until fix applied to HelixUI Issue#516', () => {
-        it('should FAIL on render with NO ID on <hx-tabset>', async () => {
+    describe('test fix applied to HelixUI Issue#516', () => {
+        it('should render with NO ID on <hx-tabset>', async () => {
             const mockup = `
                 <hx-tabset current-tab="0">
                     <hx-tablist>
@@ -126,53 +126,59 @@ describe('<hx-tabpanel> component tests', () => {
                     </hx-tabcontent>
                 </hx-tabset>`;
 
-            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabpanelElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector(elSelector).id;
+            const attr = fragment.hasAttribute('id');
+            const id = fragment.getAttribute('id');
 
-            expect(queryId).to.not.be.null;
+            expect(attr).to.be.true;
+            expect(id).to.not.be.null;
         });
 
-        it('should FAIL on render with NO initial <hx-tab>', async () => {
+        it('should render with NO initial <hx-tab>', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
+                    <hx-tabset>
+                        <hx-tablist>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
+                        <hx-tabcontent>
                           <hx-tabpanel></hx-tabpanel>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabpanelElement} */ await fixture(mockup);
-            const currentTabId = fragment.querySelector('hx-tab').id;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(currentTabId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tabpanel>', async () => {
+        it('should render with NO tabpanel', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
-                            <hx-tab id="tab-1" current="true"></hx-tab>
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                            <hx-tab></hx-tab>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
+                        <hx-tabcontent>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabpanelElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector('hx-tabpanel').id;
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const len = tabpanels.length;
 
-            expect(queryId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO tabs or tabpanels', async () => {
+        it('should render with NO tabs or tabpanels', async () => {
             const mockup = `
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tabTest">
+                    <hx-tabset>
                         <hx-tablist>
                         </hx-tablist>
                         <hx-tabcontent>
@@ -180,10 +186,12 @@ describe('<hx-tabpanel> component tests', () => {
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabpanelElement} */ await fixture(mockup);
-            const queryTabs = fragment.tabs.length;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryTabs).to.equal(0);
+            expect(len).to.equal(0);
         });
     });
 });

--- a/src/elements/hx-tabset/index.js
+++ b/src/elements/hx-tabset/index.js
@@ -26,6 +26,7 @@ export class HXTabsetElement extends HXElement {
     }
 
     $onCreate () {
+        this.$defaultAttribute('id', `tabset-${generateId()}`);
         this.$onConnect = defer(this.$onConnect);
         this._onKeyUp = this._onKeyUp.bind(this);
     }
@@ -78,9 +79,10 @@ export class HXTabsetElement extends HXElement {
         if (isNaN(idx)) {
             throw new TypeError(`'currentTab' expects a numeric index. Got ${typeof idx} instead.`);
         }
-
-        if (idx < 0 || idx >= this.tabs.length) {
-            throw new RangeError('currentTab index is out of bounds');
+        if (this.tabs.length !== 0) {
+            if (idx < 0 || idx >= this.tabs.length) {
+                throw new RangeError('currentTab index is out of bounds');
+            }
         }
 
         this.setAttribute('current-tab', idx);
@@ -222,6 +224,7 @@ export class HXTabsetElement extends HXElement {
         let tabsetId = this.getAttribute('id');
         this.tabs.forEach((tab, idx) => {
             let tabpanel = this.tabpanels[idx];
+
             // Default tab and panel ID
             let tabId = `${tabsetId}-tab-${idx}`;
             let tabpanelId = `${tabsetId}-panel-${idx}`;
@@ -234,14 +237,17 @@ export class HXTabsetElement extends HXElement {
             }
 
             // Set or keep panel ID
-            if (tabpanel.hasAttribute('id')) {
-                tabpanelId = tabpanel.getAttribute('id');
-            } else {
-                tabpanel.setAttribute('id', tabpanelId);
-            }
+            if (tabpanel !== undefined) {
+                if (tabpanel.hasAttribute('id')) {
+                    tabpanelId = tabpanel.getAttribute('id');
+                } else {
+                    tabpanel.setAttribute('id', tabpanelId);
+                }
 
-            tab.setAttribute('aria-controls', tabpanelId);
-            tabpanel.setAttribute('aria-labelledby', tabId);
+                // sync tabpanel to tab
+                tabpanel.setAttribute('aria-labelledby', tabId);
+                tab.setAttribute('aria-controls', tabpanelId);
+            }
         });
     }
 }

--- a/src/elements/hx-tabset/index.spec.js
+++ b/src/elements/hx-tabset/index.spec.js
@@ -142,13 +142,27 @@ describe('<hx-tabset> component tests', () => {
         });
     });
 
+    describe('test event listeners', () => {
+        it('should be able add click event listener', async () => {
+            const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
+            const detail = { evt: 'click'};
+            const customEvent = new CustomEvent('click', { detail });
+
+            setTimeout(() => fragment.dispatchEvent(customEvent));
+            const evt = await oneEvent(fragment, 'click');
+
+            expect(evt).to.equal(customEvent);
+            expect(evt.detail).to.equal(detail);
+        });
+    });
+
     /**
      * The following block of tests apply to all HelixUI Tab component custom
      * elements.  These tests will be skipped until we implement a solution
      * for dynamically adding tabs (HelixUI Issue#516).
      */
-    describe.skip('tests should FAIL until fix applied to HelixUI Issue#516', () => {
-        it('should FAIL on render with NO ID on <hx-tabset>', async () => {
+    describe('test fix applied to HelixUI Issue#516', () => {
+        it('should render with NO ID on <hx-tabset>', async () => {
             const mockup = `
                 <hx-tabset current-tab="0">
                     <hx-tablist>
@@ -163,53 +177,108 @@ describe('<hx-tabset> component tests', () => {
                     </hx-tabcontent>
                 </hx-tabset>`;
 
+            const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
+            const attr = fragment.hasAttribute('id');
+            const id = fragment.getAttribute('id');
+
+            expect(attr).to.be.true;
+            expect(id).to.not.be.null;
+        });
+
+        it('should render with NO initial <hx-tab>', async () => {
+            const mockup =`
+                <div class="hxPanel hxTabbed">
+                    <hx-tabset>
+                        <hx-tablist>
+                        </hx-tablist>
+                        <hx-tabcontent>
+                            <hx-tabpanel></hx-tabpanel>
+                        </hx-tabcontent>
+                    </hx-tabset>
+                </div>`;
+
             const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector(elSelector).id;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryId).to.not.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tab>', async () => {
+        it('should render with NO tabpanel', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                            <hx-tab></hx-tab>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
-                          <hx-tabpanel></hx-tabpanel>
+                        <hx-tabcontent>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
-            const currentTabId = fragment.querySelector('hx-tab').id;
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const len = tabpanels.length;
 
-            expect(currentTabId).to.be.null;
+            expect(len).to.be.equal(0);
         });
 
-        it('should FAIL on render with NO initial <hx-tabpanel>', async () => {
+
+        it('should render with an odd number of tabs and tabpanel', async () => {
             const mockup =`
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tab-component-tests">
-                        <hx-tablist id="tablist">
-                            <hx-tab id="tab-1" current="true"></hx-tab>
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                            <hx-tab></hx-tab>
                         </hx-tablist>
-                        <hx-tabcontent id="tabcontent">
+                        <hx-tabcontent>
+                            <hx-tabpanel></hx-tabpanel>
                         </hx-tabcontent>
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
-            const queryId = fragment.querySelector('hx-tabpanel').id;
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const panels = tabpanels.length;
+            const tabs = fragment.querySelector(elSelector).tabs.length;
 
-            expect(queryId).to.be.null;
+            expect(tabs).to.equal(2);
+            expect(panels).to.be.equal(1);
         });
 
-        it('should FAIL on render with NO tabs or tabpanels', async () => {
+        it('should render with an odd number of tabpanels and tab', async () => {
+            const mockup =`
+                <div class="hxPanel hxTabbed">
+                    <hx-tabset>
+                        <hx-tablist>
+                            <hx-tab></hx-tab>
+                        </hx-tablist>
+                        <hx-tabcontent>
+                            <hx-tabpanel></hx-tabpanel>
+                            <hx-tabpanel></hx-tabpanel>
+                        </hx-tabcontent>
+                    </hx-tabset>
+                </div>`;
+
+            const elSelector = 'hx-tabset';
+            const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
+            const tabpanels = fragment.querySelector(elSelector).tabpanels;
+            const panels = tabpanels.length;
+            const tabs = fragment.querySelector(elSelector).tabs.length;
+
+            expect(tabs).to.equal(1);
+            expect(panels).to.be.equal(2);
+        });
+
+        it('should render with NO tabs or tabpanels', async () => {
             const mockup = `
                 <div class="hxPanel hxTabbed">
-                    <hx-tabset id="tabTest">
+                    <hx-tabset>
                         <hx-tablist>
                         </hx-tablist>
                         <hx-tabcontent>
@@ -217,34 +286,12 @@ describe('<hx-tabset> component tests', () => {
                     </hx-tabset>
                 </div>`;
 
+            const elSelector = 'hx-tabset';
             const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
-            const queryTabs = fragment.tabs.length;
+            const tabs = fragment.querySelector(elSelector).tabs;
+            const len = tabs.length;
 
-            expect(queryTabs).to.equal(0);
+            expect(len).to.equal(0);
         });
     });
-
-    /**
-     * Event listener fails on render
-     *
-     * FAILED TESTS:
-     *     test event listeners
-     *      ✖ should be able add and remove hxtabclick event listener
-     *          Error: Uncaught RangeError: currentTab index is out of bounds
-     *
-     */
-    describe.skip('test FAIL event listeners', () => {
-        it('should be able add and remove hxtabclick event listener', async () => {
-            const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
-            const detail = { evt: 'hxtabclick'};
-            const customEvent = new CustomEvent('hxtabclick', { detail });
-
-            setTimeout(() => fragment.dispatchEvent(customEvent));
-            const evt = await oneEvent(fragment, 'hxtabclick');
-
-            expect(evt).to.equal(customEvent);
-            expect(evt.detail).to.equal(detail);
-        });
-    });
-
 });


### PR DESCRIPTION
## Description - Dynamic Tabs

* Fixes #516
* fix for dynamic tabs
* fix for no id on tabset on render
* fix for no tabpanel on render
* fix for no tab on render
* fix for no tab or tabpanel on render
* test an odd number of tabs and tabpanel
* test an odd number of tabpanels and tab

### screenshot: updated Tab Component tests (not skipped)

![Screen Shot 2020-07-31 at 5 48 09 PM](https://user-images.githubusercontent.com/10120600/89083228-f4257d80-d355-11ea-8b72-249a09b5fd86.png)


### What are the relevant story cards/tickets? Any additional PRs or other references?

Jira: SURF-1756

## Before you request a review for this PR:

- [ ] For UI changes, did you manually test in recent versions of modern browsers (Chrome, Firefox, and Safari)?
- [ ] For UI changes, did you manually test in IE11 and legacy Edge?
- [x] Did you add component tests for any new code?
- [x] Did you run the component unit tests via `yarn test` to ensure all tests passed?
- [x] Did you include a screenshot of the component tests?
- [ ] If you changed/added functionality, did you update the demo page and documentation?
- [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
- [x] Did you assign reviewers?
- [x] In Jira, have you linked to this PR on the ticket(s)?
