### PR TITLE
test(hx-tabset): add dynamic tab with id on render

### DIFF
--- a/src/elements/hx-tabset/index.spec.js
+++ b/src/elements/hx-tabset/index.spec.js
@@ -293,5 +293,41 @@ describe('<hx-tabset> component tests', () => {
 
             expect(len).to.equal(0);
         });
+
+        it.skip(`[FEATURE] should add a dynamic tab with id to empty ${template}`, async () => {
+            const mockup = `
+                <hx-tabset>
+                    <hx-tablist>
+                    </hx-tablist>
+                    <hx-tabcontent>
+                    </hx-tabcontent>
+                </hx-tabset>`;
+
+            const elSelector = 'hx-tablist > hx-tab';
+            const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
+            const tabs = fragment.tabs;
+            let firstTabCount = tabs.length;
+
+
+            // add a tab
+            const tab = document.createElement('hx-tab');
+            tab.innerHTML = "dynamic tab";
+            fragment.querySelector('hx-tablist').appendChild(tab);
+
+            const tabHasId = fragment.querySelector(elSelector).hasAttribute('id');
+            //fragment.update(); // manually add tab
+
+            // add panel
+            const tabpanel = document.createElement('hx-tabpanel');
+            tabpanel.innerHTML = "dynamic tab panel";
+            fragment.querySelector('hx-tabcontent').appendChild(tabpanel);
+            const secoundTabCount = fragment.tabs.length;
+
+            //fragment.update(); // manually add tabpanel
+
+            expect(tabHasId).to.be.true;
+            expect(firstTabCount).to.equal(0);
+            expect(secoundTabCount).to.equal(1);
+        });
     });
 });


### PR DESCRIPTION
## Description

* Feature Request from Issue #516 
* Ability to add a dynamic tab with ID on render (without needing to manually run `update()`.

### screenshot: `<hx-tabset>` dynamic tabs with id test

#### Skipped Test
<img width="619" alt="Screen Shot 2020-08-03 at 4 28 07 PM" src="https://user-images.githubusercontent.com/10120600/89242231-a82d3f80-d5c6-11ea-922a-e4fb7ae4fd82.png">


#### Failing Test
<img width="609" alt="Screen Shot 2020-08-03 at 4 28 59 PM" src="https://user-images.githubusercontent.com/10120600/89242253-b5e2c500-d5c6-11ea-9d9d-b89a1692ade8.png">

<img width="898" alt="Screen Shot 2020-08-03 at 4 28 43 PM" src="https://user-images.githubusercontent.com/10120600/89242265-bed39680-d5c6-11ea-9240-ffa52942313d.png">

 
### What are the relevant story cards/tickets? Any additional PRs or other references?

Jira: SURF-2070

## Before you request a review for this PR:

- [ ] For UI changes, did you manually test in recent versions of modern browsers (Chrome, Firefox, and Safari)?
- [ ] For UI changes, did you manually test in IE11 and legacy Edge?
- [x] Did you add component tests for any new code?
- [x] Did you run the component unit tests via `yarn test` to ensure all tests passed?
- [ ] Did you include a screenshot of the component tests?
- [ ] If you changed/added functionality, did you update the demo page and documentation?
- [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
- [x] Did you assign reviewers?
- [x] In Jira, have you linked to this PR on the ticket(s)?
