### PR TITLE
feat(tabset): implement better support for dynamic tabs

### DIFF
--- a/src/elements/hx-tab/index.js
+++ b/src/elements/hx-tab/index.js
@@ -1,4 +1,5 @@
 import { HXElement } from '../../interfaces/HXElement/index.js';
+import { generateId } from '../../utils';
 
 /**
  * Fires when non-current tab is clicked.
@@ -22,6 +23,7 @@ export class HXTabElement extends HXElement {
     }
 
     $onConnect () {
+        this.$defaultAttribute('id', `tab-${generateId()}`);
         this.$upgradeProperty('current');
         this.$defaultAttribute('role', 'tab');
         this.setAttribute('aria-selected', this.current);

--- a/src/elements/hx-tabpanel/index.js
+++ b/src/elements/hx-tabpanel/index.js
@@ -1,5 +1,5 @@
 import { HXElement } from '../../interfaces/HXElement/index.js';
-import { onScroll } from '../../utils';
+import { onScroll, generateId } from '../../utils';
 
 /**
  * Fires when the element's contents are concealed.
@@ -32,6 +32,7 @@ export class HXTabpanelElement extends HXElement {
     }
 
     $onConnect () {
+        this.$defaultAttribute('id', `tabpanel-${generateId()}`);
         this.$defaultAttribute('role', 'tabpanel');
         this.$upgradeProperty('open');
         this.setAttribute('aria-expanded', this.open);

--- a/src/elements/hx-tabset/index.js
+++ b/src/elements/hx-tabset/index.js
@@ -84,6 +84,7 @@ export class HXTabsetElement extends HXElement {
             }
         }
 
+        this._setupIds(); // account for dynamic tabs
         this.setAttribute('current-tab', idx);
     }
 
@@ -155,6 +156,7 @@ export class HXTabsetElement extends HXElement {
      * elements changes after tabset connects to the DOM.
      */
     update () {
+        this._setupIds();
         this._activateTab(this.currentTab);
     }
 

--- a/src/elements/hx-tabset/index.spec.js
+++ b/src/elements/hx-tabset/index.spec.js
@@ -294,7 +294,7 @@ describe('<hx-tabset> component tests', () => {
             expect(len).to.equal(0);
         });
 
-        it.skip(`[FEATURE] should add a dynamic tab with id to empty ${template}`, async () => {
+        it(`[FEATURE] should add a dynamic tab with id to empty ${template}`, async () => {
             const mockup = `
                 <hx-tabset>
                     <hx-tablist>
@@ -308,14 +308,12 @@ describe('<hx-tabset> component tests', () => {
             const tabs = fragment.tabs;
             let firstTabCount = tabs.length;
 
-
-            // add a tab
+            // add a dyanmic tab
             const tab = document.createElement('hx-tab');
             tab.innerHTML = "dynamic tab";
             fragment.querySelector('hx-tablist').appendChild(tab);
 
             const tabHasId = fragment.querySelector(elSelector).hasAttribute('id');
-            //fragment.update(); // manually add tab
 
             // add panel
             const tabpanel = document.createElement('hx-tabpanel');
@@ -323,11 +321,47 @@ describe('<hx-tabset> component tests', () => {
             fragment.querySelector('hx-tabcontent').appendChild(tabpanel);
             const secoundTabCount = fragment.tabs.length;
 
-            //fragment.update(); // manually add tabpanel
+            fragment.update();
 
             expect(tabHasId).to.be.true;
             expect(firstTabCount).to.equal(0);
             expect(secoundTabCount).to.equal(1);
+        });
+
+        it(`[FEATURE] should add a dynamic tab with id to a populated ${template}`, async () => {
+            const mockup = `
+                <hx-tabset>
+                    <hx-tablist>
+                        <hx-tab id="dynamicTestTab"></hx-tab>
+                    </hx-tablist>
+                    <hx-tabcontent>
+                        <hx-tabpanel id="dynamicTestTabpanel"></hx-tabpanel>
+                    </hx-tabcontent>
+                </hx-tabset>`;
+
+            const elSelector = 'hx-tablist > hx-tab';
+            const fragment = /** @type {HXTabsetElement} */ await fixture(mockup);
+            const tabs = fragment.tabs;
+            let firstTabCount = tabs.length;
+
+            // add a dyanmic tab
+            const tab = document.createElement('hx-tab');
+            tab.innerHTML = "dynamic tab";
+            fragment.querySelector('hx-tablist').appendChild(tab);
+
+            const tabHasId = fragment.querySelector(elSelector).hasAttribute('id');
+
+            // add panel
+            const tabpanel = document.createElement('hx-tabpanel');
+            tabpanel.innerHTML = "dynamic tab panel";
+            fragment.querySelector('hx-tabcontent').appendChild(tabpanel);
+            const secoundTabCount = fragment.tabs.length;
+
+            fragment.update(); // update tab
+
+            expect(tabHasId).to.be.true;
+            expect(firstTabCount).to.equal(1);
+            expect(secoundTabCount).to.equal(2);
         });
     });
 });


### PR DESCRIPTION
## Description

Implement better support for dynamic tabs. (Requested Issue #516 and Issue #758)

## Screenshot of new `<hx-tabset>` dynamic tabs tests

<img width="614" alt="Screen Shot 2020-10-07 at 2 20 38 PM" src="https://user-images.githubusercontent.com/10120600/95377649-7e371880-08a8-11eb-9463-5339c6400149.png">

### What are the relevant story cards/tickets? Any additional PRs or other references?

Jira: SURF-2071

## Before you request a review for this PR:

- [ ] For UI changes, did you manually test in recent versions of modern browsers (Chrome, Firefox, and Safari)?
- [ ] For UI changes, did you manually test in IE11 and legacy Edge?
- [x] Did you add component tests for any new code?
- [x] Did you run the component unit tests via `yarn test` to ensure all tests passed?
- [ ] Did you include a screenshot of the component tests?
- [ ] If you changed/added functionality, did you update the demo page and documentation?
- [ ] If needed, did you add or modify the demo test page to test the changed/added functionality?
- [x] Did you assign reviewers?
- [x] In Jira, have you linked to this PR on the ticket(s)?
