### PR TITLE
chore(docs): tweak docs `header`

### DIFF
--- a/docs/_layout.scss
+++ b/docs/_layout.scss
@@ -11,7 +11,7 @@ body.hxVertical {
     }
 
     > header {
-      background-color: $gray-50;
+      background-color: $gray-100;
       border-color: $gray-100;
       border-style: solid;
       border-width: 0 0 1px;


### PR DESCRIPTION
## Description

* Tweak docs `header` for new color palette specs.

## Before
<img width="1078" alt="Screen Shot 2021-07-28 at 3 37 25 PM" src="https://user-images.githubusercontent.com/10120600/127392631-49eb7dd2-3567-48d6-b44e-c835eb5b4a19.png">

## After
<img width="1070" alt="Screen Shot 2021-07-28 at 3 39 30 PM" src="https://user-images.githubusercontent.com/10120600/127392687-48080b65-117f-476a-bb07-91806f2b57b4.png">
